### PR TITLE
Загрузка строк подключения из App.config и appsettings.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+## [2.2.1] - 2023-12-22
+
+### Changed
+* improved reading connection string from `App.config` [#19](https://github.com/Flexberry/NewPlatform.Flexberry.LogService/pull/19):
+  - `appSettings.DefaultConnectionStringName` is used when `ConnectionString`/`ConnectionStringName` are not specified in `CustomAdoNetAppender`
+  - `CustomAdoNetAppender` falls back to `appSettings.CustomizationStrings` property when no connection string is specified elsewhere
+
+### Fixed
+* reading connection string from `appsettings.json` is fixed [#19](https://github.com/Flexberry/NewPlatform.Flexberry.LogService/pull/19)
+
 ## [2.2.0] - 2023-12-21
 
 ### Changed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Authors>New Platform Ltd.</Authors>
     <Copyright>Copyright 2017-2022 © New Platform Ltd.</Copyright>
     <Company>New Platform Ltd.</Company>
-    <VersionPrefix>2.2.0</VersionPrefix>
+    <VersionPrefix>2.2.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageProjectUrl>https://flexberry.net</PackageProjectUrl>
     <PackageIcon>icon.png</PackageIcon>

--- a/NewPlatform.Flexberry.LogService.Tests/CustomAdoNetAppenderTest.cs
+++ b/NewPlatform.Flexberry.LogService.Tests/CustomAdoNetAppenderTest.cs
@@ -1,6 +1,14 @@
-﻿namespace LogService.Tests
+﻿namespace NewPlatform.Flexberry.LogService.Tests
 {
+    using System.Configuration;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+
     using ICSSoft.STORMNET;
+
+    using log4net;
+    using log4net.Config;
 
     using Xunit;
 
@@ -27,6 +35,84 @@
 
             // Assert.
             Assert.Equal(ApplicationConnectionString, actual);
+        }
+
+        /// <summary>
+        /// Test for reading connection string from appsettings.json and App.config.
+        /// </summary>
+        [Fact]
+        public void ReadConnectionStringTest()
+        {
+            // Prepare
+            PrepareLog4Net("App.config");
+
+            // Act
+            var adoNetAppender = LogService.Log.Logger.Repository.GetAppenders().First(x => x is CustomAdoNetAppender) as CustomAdoNetAppender;
+            string connStr = adoNetAppender.GetConnectionStringFromConfiguration();
+
+            // Assert
+            Assert.NotNull(connStr);
+#if NETCOREAPP
+            Assert.DoesNotContain("SERVER=app.config.string", connStr);
+#else
+            Assert.Contains("SERVER=app.config.string", connStr);
+#endif
+        }
+
+        /// <summary>
+        /// Test for utilizing DefaultConnectionStringName parameter in App.config.
+        /// </summary>
+        [Fact]
+        public void ReadDefaultConnectionStringTest()
+        {
+            // Prepare
+            PrepareLog4Net("App.defconnstr.config");
+
+            // Act
+            var adoNetAppender = LogService.Log.Logger.Repository.GetAppenders().First(x => x is CustomAdoNetAppender) as CustomAdoNetAppender;
+            string connStr = adoNetAppender.GetConnectionStringFromConfiguration();
+
+            // Assert
+            Assert.NotNull(connStr);
+            Assert.Contains("SERVER=app.config.defconnstr", connStr);
+        }
+
+        /// <summary>
+        /// Test for utilizing CustomizationStrings parameter when no connection string is specified in App.config.
+        /// </summary>
+        [Fact]
+        public void ReadCustomizationStringsTest()
+        {
+            // Prepare
+            PrepareLog4Net("App.customizationstrings.config");
+
+            // Act
+            var adoNetAppender = LogService.Log.Logger.Repository.GetAppenders().First(x => x is CustomAdoNetAppender) as CustomAdoNetAppender;
+            string connStr = adoNetAppender.GetConnectionStringFromConfiguration();
+
+            // Assert
+            Assert.NotNull(connStr);
+            Assert.Contains("SERVER=app.config.customizationstrings", connStr);
+        }
+
+        /// <summary>
+        /// Initialize log4net with specified configuration file.
+        /// </summary>
+        /// <param name="fileName">Configuration file name.</param>
+        private void PrepareLog4Net(string fileName)
+        {
+            // Replace testhost.dll.config with specified configuration file:
+            var exeAssembly = Assembly.GetExecutingAssembly();
+            string configFilePath = Path.Combine(Path.GetDirectoryName(exeAssembly.Location), fileName);
+            string outputConfigFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None).FilePath;
+            File.Copy(configFilePath, outputConfigFile, true);
+
+            // Refresh sections for log4net initialization:
+            ConfigurationManager.RefreshSection("appSettings");
+            ConfigurationManager.RefreshSection("connectionStrings");
+
+            var logRepository = LogManager.GetRepository(exeAssembly);
+            XmlConfigurator.Configure(logRepository, new FileInfo(configFilePath));
         }
     }
 }

--- a/NewPlatform.Flexberry.LogService.Tests/Log4net.Configs/App.config
+++ b/NewPlatform.Flexberry.LogService.Tests/Log4net.Configs/App.config
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<configSections>
+		<section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+	</configSections>
+	<connectionStrings>
+		<add name="DefConnStr" connectionString="SERVER=app.config.string;User ID=postgres;Password=postgres;Port=5432;database=appdb;" />
+	</connectionStrings>
+	<log4net update="Overwrite">
+		<appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%date [%thread] %-5level %logger [%ndc] - %message%newline" />
+			</layout>
+		</appender>
+		<appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
+			<file value="example.log" />
+			<appendToFile value="true" />
+			<maximumFileSize value="100KB" />
+			<maxSizeRollBackups value="2" />
+			<layout type="log4net.Layout.PatternLayout">
+				<conversionPattern value="%level %thread %logger - %message%newline" />
+			</layout>
+		</appender>
+		<appender name="AdoNetAppender" type="ICSSoft.STORMNET.CustomAdoNetAppender, NewPlatform.Flexberry.LogService">
+			<bufferSize value="0" />
+			<reconnectonerror value="true" />
+			<connectionType value="Npgsql.NpgsqlConnection, Npgsql" />
+			<ConnectionStringName value="DefConnStr" />
+			<commandText value="INSERT INTO ApplicationLog (primaryKey,Timestamp,ThreadName,Category,ProcessName,Message,FormattedMessage) VALUES (uuid_in(md5(random()::text || now()::text)::cstring), :log_date, :thread, :log_level, :logger, :message, :exception)" />
+			<parameter>
+				<parameterName value="@log_date" />
+				<dbType value="DateTime" />
+				<layout type="log4net.Layout.RawUtcTimeStampLayout" />
+			</parameter>
+			<parameter>
+				<parameterName value="@thread" />
+				<dbType value="String" />
+				<size value="512" />
+				<layout type="log4net.Layout.PatternLayout">
+					<conversionPattern value="%thread" />
+				</layout>
+			</parameter>
+			<parameter>
+				<parameterName value="@log_level" />
+				<dbType value="String" />
+				<size value="64" />
+				<layout type="log4net.Layout.PatternLayout">
+					<conversionPattern value="%level" />
+				</layout>
+			</parameter>
+			<parameter>
+				<parameterName value="@logger" />
+				<dbType value="String" />
+				<size value="512" />
+				<layout type="log4net.Layout.PatternLayout">
+					<conversionPattern value="%logger" />
+				</layout>
+			</parameter>
+			<parameter>
+				<parameterName value="@message" />
+				<dbType value="String" />
+				<size value="2500" />
+				<layout type="log4net.Layout.PatternLayout">
+					<conversionPattern value="%message" />
+				</layout>
+			</parameter>
+			<parameter>
+				<parameterName value="@exception" />
+				<dbType value="String" />
+				<size value="4000" />
+				<layout type="log4net.Layout.ExceptionLayout" />
+			</parameter>
+		</appender>
+		<root>
+			<level value="DEBUG" />
+			<appender-ref ref="ConsoleAppender" />
+			<appender-ref ref="RollingFileAppender" />
+			<appender-ref ref="AdoNetAppender" />
+		</root>
+	</log4net>
+</configuration>

--- a/NewPlatform.Flexberry.LogService.Tests/Log4net.Configs/App.customizationstrings.config
+++ b/NewPlatform.Flexberry.LogService.Tests/Log4net.Configs/App.customizationstrings.config
@@ -1,0 +1,64 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<configSections>
+		<section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+	</configSections>
+	<appSettings>
+		<add key="CustomizationStrings" value="SERVER=app.config.customizationstrings;User ID=postgres;Password=postgres;Port=5432;database=appdb;" />
+	</appSettings>
+	<log4net update="Overwrite">
+		<appender name="AdoNetAppender" type="ICSSoft.STORMNET.CustomAdoNetAppender, NewPlatform.Flexberry.LogService">
+			<bufferSize value="0" />
+			<reconnectonerror value="true" />
+			<connectionType value="Npgsql.NpgsqlConnection, Npgsql" />
+			<commandText value="INSERT INTO ApplicationLog (primaryKey,Timestamp,ThreadName,Category,ProcessName,Message,FormattedMessage) VALUES (uuid_in(md5(random()::text || now()::text)::cstring), :log_date, :thread, :log_level, :logger, :message, :exception)" />
+			<parameter>
+				<parameterName value="@log_date" />
+				<dbType value="DateTime" />
+				<layout type="log4net.Layout.RawUtcTimeStampLayout" />
+			</parameter>
+			<parameter>
+				<parameterName value="@thread" />
+				<dbType value="String" />
+				<size value="512" />
+				<layout type="log4net.Layout.PatternLayout">
+					<conversionPattern value="%thread" />
+				</layout>
+			</parameter>
+			<parameter>
+				<parameterName value="@log_level" />
+				<dbType value="String" />
+				<size value="64" />
+				<layout type="log4net.Layout.PatternLayout">
+					<conversionPattern value="%level" />
+				</layout>
+			</parameter>
+			<parameter>
+				<parameterName value="@logger" />
+				<dbType value="String" />
+				<size value="512" />
+				<layout type="log4net.Layout.PatternLayout">
+					<conversionPattern value="%logger" />
+				</layout>
+			</parameter>
+			<parameter>
+				<parameterName value="@message" />
+				<dbType value="String" />
+				<size value="2500" />
+				<layout type="log4net.Layout.PatternLayout">
+					<conversionPattern value="%message" />
+				</layout>
+			</parameter>
+			<parameter>
+				<parameterName value="@exception" />
+				<dbType value="String" />
+				<size value="4000" />
+				<layout type="log4net.Layout.ExceptionLayout" />
+			</parameter>
+		</appender>
+		<root>
+			<level value="DEBUG" />
+			<appender-ref ref="AdoNetAppender" />
+		</root>
+	</log4net>
+</configuration>

--- a/NewPlatform.Flexberry.LogService.Tests/Log4net.Configs/App.defconnstr.config
+++ b/NewPlatform.Flexberry.LogService.Tests/Log4net.Configs/App.defconnstr.config
@@ -4,28 +4,16 @@
 		<section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
 	</configSections>
 	<connectionStrings>
-		<add name="DefConnStr" connectionString="SERVER=app.config.string;User ID=postgres;Password=postgres;Port=5432;database=appdb;" />
+		<add name="DefaultConnStr" connectionString="SERVER=app.config.defconnstr;User ID=postgres;Password=postgres;Port=5432;database=appdb;" />
 	</connectionStrings>
-	<log4net>
-		<appender name="ConsoleAppender" type="log4net.Appender.ConsoleAppender">
-			<layout type="log4net.Layout.PatternLayout">
-				<conversionPattern value="%date [%thread] %-5level %logger [%ndc] - %message%newline" />
-			</layout>
-		</appender>
-		<appender name="RollingFileAppender" type="log4net.Appender.RollingFileAppender">
-			<file value="example.log" />
-			<appendToFile value="true" />
-			<maximumFileSize value="100KB" />
-			<maxSizeRollBackups value="2" />
-			<layout type="log4net.Layout.PatternLayout">
-				<conversionPattern value="%level %thread %logger - %message%newline" />
-			</layout>
-		</appender>
+	<appSettings>
+		<add key="DefaultConnectionStringName" value="DefaultConnStr" />
+	</appSettings>
+	<log4net update="Overwrite">
 		<appender name="AdoNetAppender" type="ICSSoft.STORMNET.CustomAdoNetAppender, NewPlatform.Flexberry.LogService">
 			<bufferSize value="0" />
 			<reconnectonerror value="true" />
 			<connectionType value="Npgsql.NpgsqlConnection, Npgsql" />
-			<ConnectionStringName value="DefConnStr" />
 			<commandText value="INSERT INTO ApplicationLog (primaryKey,Timestamp,ThreadName,Category,ProcessName,Message,FormattedMessage) VALUES (uuid_in(md5(random()::text || now()::text)::cstring), :log_date, :thread, :log_level, :logger, :message, :exception)" />
 			<parameter>
 				<parameterName value="@log_date" />
@@ -73,8 +61,6 @@
 		</appender>
 		<root>
 			<level value="DEBUG" />
-			<appender-ref ref="ConsoleAppender" />
-			<appender-ref ref="RollingFileAppender" />
 			<appender-ref ref="AdoNetAppender" />
 		</root>
 	</log4net>

--- a/NewPlatform.Flexberry.LogService.Tests/LogServiceTest.cs
+++ b/NewPlatform.Flexberry.LogService.Tests/LogServiceTest.cs
@@ -1,7 +1,6 @@
 ﻿namespace NewPlatform.Flexberry.LogService.Tests
 {
     using ICSSoft.STORMNET;
-    using System.Linq;
     using Xunit;
 
     /// <summary>
@@ -16,22 +15,6 @@
         public void LogErrorTest()
         {
             LogService.LogError("Bums");
-        }
-
-        /// <summary>
-        /// Test for reading connection string from appsettings.json and App.config.
-        /// </summary>
-        [Fact]
-        public void ReadConnectionStringTest()
-        {
-            var adoNetAppender = LogService.Log.Logger.Repository.GetAppenders().First(x => x is CustomAdoNetAppender) as CustomAdoNetAppender;
-            var connStr = adoNetAppender.GetConnectionStringFromConfiguration();
-            Assert.NotNull(connStr);
-#if NETCOREAPP
-            Assert.DoesNotContain("SERVER=app.config.string", connStr);
-#else
-            Assert.Contains("SERVER=app.config.string", connStr);
-#endif
         }
     }
 }

--- a/NewPlatform.Flexberry.LogService.Tests/NewPlatform.Flexberry.LogService.Tests.csproj
+++ b/NewPlatform.Flexberry.LogService.Tests/NewPlatform.Flexberry.LogService.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net7.0</TargetFrameworks>
     <RootNamespace>NewPlatform.Flexberry.LogService.Tests</RootNamespace>
     <AssemblyName>NewPlatform.Flexberry.LogService.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>NewPlatform.Flexberry.LogService.Tests.snk</AssemblyOriginatorKeyFile>
@@ -19,7 +19,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net7.0' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
   </ItemGroup>
 
@@ -28,10 +28,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="App.config">
+    <None Update="Log4net.Configs\App.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Log4net.Configs\App.customizationstrings.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Log4net.Configs\App.defconnstr.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/NewPlatform.Flexberry.LogService.Tests/Utils.cs
+++ b/NewPlatform.Flexberry.LogService.Tests/Utils.cs
@@ -1,0 +1,25 @@
+﻿namespace NewPlatform.Flexberry.LogService.Tests
+{
+    using System.IO;
+
+    /// <summary>
+    /// Утилиты для тестов.
+    /// </summary>
+    public static class Utils
+    {
+        public static void CopyFilesRecursively(string sourcePath, string targetPath)
+        {
+            //Now Create all of the directories
+            foreach (string dirPath in Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories))
+            {
+                Directory.CreateDirectory(dirPath.Replace(sourcePath, targetPath));
+            }
+
+            //Copy all the files & Replaces any files with the same name
+            foreach (string newPath in Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories))
+            {
+                File.Copy(newPath, newPath.Replace(sourcePath, targetPath), true);
+            }
+        }
+    }
+}

--- a/NewPlatform.Flexberry.LogService.Tests/XUnitTestRunnerInitializer.cs
+++ b/NewPlatform.Flexberry.LogService.Tests/XUnitTestRunnerInitializer.cs
@@ -2,12 +2,13 @@
 
 namespace NewPlatform.Flexberry.LogService.Tests
 {
-#if NETCOREAPP
-    using log4net;
-    using log4net.Config;
-    using System.Configuration;
+    using System;
     using System.IO;
     using System.Reflection;
+#if NETCOREAPP
+    using System.Configuration;
+    using log4net;
+    using log4net.Config;
 #endif
     using Xunit.Abstractions;
     using Xunit.Sdk;
@@ -25,14 +26,20 @@ namespace NewPlatform.Flexberry.LogService.Tests
             : base(messageSink)
         {
 #if NETCOREAPP
+            // Copy App.config into testhost.dll.config:
             string configFile = $"{Assembly.GetExecutingAssembly().Location}.config";
             string outputConfigFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None).FilePath;
             File.Copy(configFile, outputConfigFile, true);
-            
-            // Init logging using correct configuration file:
+
+            // Refresh log4net configuration:
             var logRepository = LogManager.GetRepository(Assembly.GetEntryAssembly());
             XmlConfigurator.Configure(logRepository, new FileInfo(outputConfigFile));
 #endif
+
+            // Copy other test configurations from Log4net.Configs folder:
+            string entryAssemblyPath = AppDomain.CurrentDomain.BaseDirectory;
+            string exeAssemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            Utils.CopyFilesRecursively(Path.Combine(entryAssemblyPath, "Log4net.Configs"), exeAssemblyPath);
         }
     }
 }

--- a/NewPlatform.Flexberry.LogService/StringExtensions.cs
+++ b/NewPlatform.Flexberry.LogService/StringExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ICSSoft.STORMNET
+{
+    /// <summary>
+    /// Расширения для работы со строками.
+    /// </summary>
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Вернуть null если строка пустая (нужен для null-coalescing ?? оператора).
+        /// </summary>
+        /// <param name="s">Проверяемая строка.</param>
+        /// <returns>null если строка пустая.</returns>
+        public static string NullIfEmpty(this string s)
+        {
+            return string.IsNullOrEmpty(s) ? null : s;
+        }
+    }
+}


### PR DESCRIPTION
До этого строки подключения загружались из файлов конфигурации только через параметр `ConnectionStringName` у `AdoNetAppender`. 

Теперь работает возможность:
- указать название строки по умолчанию `appSettings.DefaultConnectionStringName`
- fallback до `appSettings.CustomizationStrings` если строки не заданы
- указать строку подключения в `appsettings.json` (должен быть задан параметр `ConnectionStringName` у `AdoNetAppender`)

Добавлены тесты для каждого случая.